### PR TITLE
Add support to messages array in generatePrompt

### DIFF
--- a/services/mallam.ts
+++ b/services/mallam.ts
@@ -7,15 +7,15 @@ interface Props {
   stream?: boolean;
 }
 
+interface ChatCompletionMessageParam {
+  role: string;
+  content: string;
+}
+
 interface Usage {
   prompt_tokens: number;
   total_tokens: number;
   completion_tokens: number;
-}
-
-interface Message {
-  role: string;
-  content: string;
 }
 
 interface MallamResponse {
@@ -26,7 +26,7 @@ interface MallamResponse {
 
 interface MallamAgent {
   generatePrompt(prompt: string): Promise<MallamResponse>;
-  generatePrompt(messages: Message[]): Promise<MallamResponse>;
+  generatePrompt(messages: ChatCompletionMessageParam[]): Promise<MallamResponse>;
 }
 
 export class Mallam implements MallamAgent {
@@ -48,14 +48,12 @@ export class Mallam implements MallamAgent {
     this.props = { ...defaultProps, ...props };
   }
 
-  generatePrompt = async (
-    prompt: string | Message[]
-  ): Promise<MallamResponse> => {
+  generatePrompt = async (prompt: string | ChatCompletionMessageParam[]): Promise<MallamResponse> => {
     const myHeaders = new Headers();
     myHeaders.append("Authorization", `Bearer ${this.apiKey}`);
     myHeaders.append("Content-Type", "application/json");
 
-    let messages: Message[] = [];
+    let messages: ChatCompletionMessageParam[] = [];
     if (typeof prompt === "string") {
       messages = [
         {

--- a/services/mallam.ts
+++ b/services/mallam.ts
@@ -1,4 +1,4 @@
-type Props = {
+interface Props {
   model?: string;
   temperature?: number;
   top_p?: number;
@@ -13,14 +13,19 @@ interface Usage {
   completion_tokens: number;
 }
 
-type MallamResponse = {
+interface Message {
+  role: string;
+  content: string;
+}
+
+interface MallamResponse {
   id: string;
   message: string;
   usage: Usage;
 }
 
-type MallamAgent = {
-  generatePrompt: (prompt: string) => Promise<MallamResponse>;
+interface MallamAgent {
+  generatePrompt(prompt: string): Promise<MallamResponse>;
 }
 
 export class Mallam implements MallamAgent {
@@ -36,7 +41,7 @@ export class Mallam implements MallamAgent {
       top_p: 0.95,
       top_k: 50,
       max_tokens: 256,
-      stream: false
+      stream: false,
     };
 
     this.props = { ...defaultProps, ...props };
@@ -48,47 +53,45 @@ export class Mallam implements MallamAgent {
     myHeaders.append("Content-Type", "application/json");
 
     const raw = JSON.stringify({
-      "model": this.props.model,
-      "temperature": this.props.temperature,
-      "top_p": this.props.top_p,
-      "top_k": this.props.top_k,
-      "max_tokens": this.props.max_tokens,
-      "stop": [
-        "[/INST]",
-        "[INST]",
-        "<s>"
-      ],
-      "messages": [
+      model: this.props.model,
+      temperature: this.props.temperature,
+      top_p: this.props.top_p,
+      top_k: this.props.top_k,
+      max_tokens: this.props.max_tokens,
+      stop: ["[/INST]", "[INST]", "<s>"],
+      messages: [
         {
-          "role": "user",
-          "content": prompt
-        }
+          role: "user",
+          content: prompt,
+        },
       ],
-      "tools": null,
-      "stream": this.props.stream
+      tools: null,
+      stream: this.props.stream,
     });
 
-    const res = await fetch("https://llm-router.nous.mesolitica.com/chat/completions", {
-      method: 'POST',
-      headers: myHeaders,
-      body: raw,
-      redirect: 'follow'
-    })
+    const res = await fetch(
+      "https://llm-router.nous.mesolitica.com/chat/completions",
+      {
+        method: "POST",
+        headers: myHeaders,
+        body: raw,
+        redirect: "follow",
+      }
+    );
 
     if (!res.ok) {
       throw new Error(`HTTP error! status: ${res.status}`);
     }
 
-    const text = JSON.parse(await res.text())
+    const text = JSON.parse(await res.text());
 
     const result = {
       id: text.id,
       prompt,
       message: text.choices[0].message.content,
-      usage: text.usage
-    } as MallamResponse
+      usage: text.usage,
+    } as MallamResponse;
 
-    return result
-  }
-
+    return result;
+  };
 }

--- a/services/mallam.ts
+++ b/services/mallam.ts
@@ -26,6 +26,7 @@ interface MallamResponse {
 
 interface MallamAgent {
   generatePrompt(prompt: string): Promise<MallamResponse>;
+  generatePrompt(messages: Message[]): Promise<MallamResponse>;
 }
 
 export class Mallam implements MallamAgent {

--- a/services/mallam.ts
+++ b/services/mallam.ts
@@ -48,10 +48,24 @@ export class Mallam implements MallamAgent {
     this.props = { ...defaultProps, ...props };
   }
 
-  generatePrompt = async (prompt: string): Promise<MallamResponse> => {
+  generatePrompt = async (
+    prompt: string | Message[]
+  ): Promise<MallamResponse> => {
     const myHeaders = new Headers();
     myHeaders.append("Authorization", `Bearer ${this.apiKey}`);
     myHeaders.append("Content-Type", "application/json");
+
+    let messages: Message[] = [];
+    if (typeof prompt === "string") {
+      messages = [
+        {
+          role: "user",
+          content: prompt,
+        },
+      ];
+    } else {
+      messages = prompt;
+    }
 
     const raw = JSON.stringify({
       model: this.props.model,
@@ -60,12 +74,7 @@ export class Mallam implements MallamAgent {
       top_k: this.props.top_k,
       max_tokens: this.props.max_tokens,
       stop: ["[/INST]", "[INST]", "<s>"],
-      messages: [
-        {
-          role: "user",
-          content: prompt,
-        },
-      ],
+      messages,
       tools: null,
       stream: this.props.stream,
     });

--- a/services/mallam.ts
+++ b/services/mallam.ts
@@ -42,7 +42,7 @@ export class Mallam implements MallamAgent {
       top_p: 0.95,
       top_k: 50,
       max_tokens: 256,
-      stream: false,
+      stream: false
     };
 
     this.props = { ...defaultProps, ...props };
@@ -66,40 +66,42 @@ export class Mallam implements MallamAgent {
     }
 
     const raw = JSON.stringify({
-      model: this.props.model,
-      temperature: this.props.temperature,
-      top_p: this.props.top_p,
-      top_k: this.props.top_k,
-      max_tokens: this.props.max_tokens,
-      stop: ["[/INST]", "[INST]", "<s>"],
-      messages,
-      tools: null,
-      stream: this.props.stream,
+      "model": this.props.model,
+      "temperature": this.props.temperature,
+      "top_p": this.props.top_p,
+      "top_k": this.props.top_k,
+      "max_tokens": this.props.max_tokens,
+      "stop": [
+        "[/INST]",
+        "[INST]",
+        "<s>"
+      ],
+      "messages": messages,
+      "tools": null,
+      "stream": this.props.stream
     });
 
-    const res = await fetch(
-      "https://llm-router.nous.mesolitica.com/chat/completions",
-      {
-        method: "POST",
-        headers: myHeaders,
-        body: raw,
-        redirect: "follow",
-      }
-    );
+    const res = await fetch("https://llm-router.nous.mesolitica.com/chat/completions", {
+      method: 'POST',
+      headers: myHeaders,
+      body: raw,
+      redirect: 'follow'
+    })
 
     if (!res.ok) {
       throw new Error(`HTTP error! status: ${res.status}`);
     }
 
-    const text = JSON.parse(await res.text());
+    const text = JSON.parse(await res.text())
 
     const result = {
       id: text.id,
       prompt,
       message: text.choices[0].message.content,
-      usage: text.usage,
-    } as MallamResponse;
+      usage: text.usage
+    } as MallamResponse
 
-    return result;
-  };
+    return result
+  }
+
 }


### PR DESCRIPTION
This PR allows user to send an array of messages 
```
{
  role: string
  content: string
}[]
```
to the `generatePrompt` method

A common use case is to set the system role
```
[
  {
    role: "system",
    content: "Anda adalah seorang programmer yang hebat"
  },
  {
    role: "user",
    content: "Selesaikan masalah coding ini"
  },
]
```

Also standardized the type definition to use `interface`. However, I'm okay to revert it back to the previous usage of `type`